### PR TITLE
Added "search path"

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,12 @@ Or:
 
 ### Additions
 
-* Currently the source of the runtime system hasn't been changed, however I have shuffled the various executables around for clarity.
+I have _mostly_ shuffled the various executables around for clarity, and added some new things to the file-tree located beneath [dist/](dist/).
+
+In terms of new features to the system-core I have patched the CCP (command-processor) component of CP/M to look for failed files upon the A: drive if they're not found in the named/current drive.
+
+Otherwise changes are only shuffling and the addition of new binaries, as noted:
+
 * I've added a copy of DX Forth beneath [F:](dist/CPM/DISKS/F).
 * I've added a copy of the Turbo Pascal compiler beneath [P:](dist/CPM/DISKS/P).
   * I wrote a simple [getting started with Turbo Pascal](TURBO.md) guide.

--- a/ccp.asm
+++ b/ccp.asm
@@ -141,10 +141,31 @@ OPEN:	LD	C,15
 ;
 ;   Routine to open file at (FCB).
 ;
+;   This is used either for loading-files, or for finding files for TYPE
+;
 OPENFCB:XOR	A		;clear the record number byte at fcb+32
 	LD	(FCB+32),A
 	LD	DE,FCB
-	JP	OPEN
+	LD      C,15
+        CALL    ENTRY
+	LD	(RTNCODE),A	;save return code.
+	INC	A		;set zero if 0ffh returned.
+        JP      NZ,OPEN_OK      ;no error finding the file.
+
+        ;; ok open failed, try again with A:, just in case that helps
+        LD A,1
+        LD (CHGDRV),A
+        CALL    DSELECT
+
+        LD	DE,FCB
+	LD      C,15
+        CALL    ENTRY
+	LD	(RTNCODE),A	;save return code.
+	INC	A		;set zero if 0ffh returned.
+OPEN_OK:
+        RET
+
+
 ;
 ;   Routine to close a file. (DE) points to FCB.
 ;
@@ -1762,6 +1783,3 @@ CDRIVE:	DEFB	0		;currently active drive.
 CHGDRV:	DEFB	0		;change in drives flag (0=no change).
 NBYTES:	DEFW	0		;byte counter used by TYPE.
 ;
-
-
-


### PR DESCRIPTION
When the CCP (CP/M Command Processor) tries to run executables it
will look for failing binaries on the A: drive, if finding them
on the named/current drive fails.

This might have some odd effects, so I'll have to keep an eye upon it.