### PR TITLE
Ctrl-c aborts input at the CP/M prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,12 @@ Now configure things to look for unknown commands on the A: drive, confirming th
 
 I've removed the undocumented (imp)ort and (exp)ort commands, to cut down on space, and avoid confusion.
 
-Although I'd like to improve the console input functions, for the moment I've just updated things such that the backspace key deletes the most recently entered character at the CP/M prompt.  (This is in addition to the keystroke `C-h` continuing to work in that same way.)
+I've just updated the input-handler such that:
+
+* The backspace key deletes the most recently entered character at the CP/M prompt.
+  * (This is in addition to the keystroke `C-h` continuing to work in that same way.)
+* Ctrl-c entered at the CP/M prompt cancels input.
+  * (It returns an empty input-buffer, so it allows easy discarding.)
 
 Possible future changes might involve:
 

--- a/bdos.asm
+++ b/bdos.asm
@@ -197,10 +197,12 @@ BDOS_Read_Console_Buffer1:
     pop hl
     cp 13                       ; Done?
     jr z, BDOS_Read_Console_Buffer2
-    cp 8                        ; Backspace key?
+    cp 8                        ; Ctrl-H key?
     jr z, BDOS_Read_Console_Buffer_Backspace
-    cp 127
+    cp 127                      ; Backspace
     jr z, BDOS_Read_Console_Buffer_Backspace
+    cp 3
+    jr z,BDOS_Read_Console_Clear_Line ; ctrl-c -> reset line
     ld (de), a                  ; Store the char in the buffer
     inc (hl)                    ; Increase the final-chars-count
     inc de                      ; Move on to next place in buffer
@@ -208,7 +210,15 @@ BDOS_Read_Console_Buffer1:
     djnz  BDOS_Read_Console_Buffer1
 BDOS_Read_Console_Buffer2:
     ld b, 0
-	ret
+    ret
+
+BDOS_Read_Console_Clear_Line:
+        ld (hl),0                   ; zero characters entered
+        inc hl
+        ld (hl),0               ; first character is a null
+        ld b,0
+        ret
+
 BDOS_Read_Console_Buffer_Backspace:
     ld a, (hl)                  ; If final-chars is zero we can't go back any more
     cp 0


### PR DESCRIPTION
This is a quick hack, but seems sensible enough.